### PR TITLE
Add spellcheck vs code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "davidanson.vscode-markdownlint",
         "ms-python.python",
-        "redhat.vscode-yaml"
+        "redhat.vscode-yaml",
+        "streetsidesoftware.code-spell-checker"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+    "cSpell.enabled": true,
+    "cSpell.enableFiletypes": [
+        "!yaml",
+    ],
     "yaml.schemas": {
         "https://squidfunk.github.io/mkdocs-material/schema.json": "mkdocs.yml"
     },
@@ -6,5 +10,5 @@
         "!ENV",
         "tag:yaml.org,2002:python/name:materialx.emoji.twemoji",
         "tag:yaml.org,2002:python/name:materialx.emoji.to_svg"
-    ]
+    ],
 }


### PR DESCRIPTION
Resolves #20 

Instead of adding spellcheck to the workflows, use a VS Code extension